### PR TITLE
fix: support custom mode(e.g. vite --mode dev)

### DIFF
--- a/packages/vite-plugin-external/src/index.ts
+++ b/packages/vite-plugin-external/src/index.ts
@@ -73,7 +73,7 @@ export default function createPlugin(opts: Options): Plugin {
   return {
     name: 'vite-plugin-external',
     enforce: opts.enforce,
-    config(config: UserConfig, { mode }: ConfigEnv) {
+    config(config: UserConfig, { mode, command }: ConfigEnv) {
       const modeOptions: Options | undefined = opts[mode];
 
       externals = Object.assign({}, opts.externals, modeOptions && modeOptions.externals);
@@ -85,7 +85,7 @@ export default function createPlugin(opts: Options): Plugin {
       }
 
       // non development
-      if (mode !== 'development') {
+      if (command !== 'serve') {
         let { build } = config;
 
         // if no build indicates


### PR DESCRIPTION
您好，感谢您开源的插件！

我在项目中使用 `vite --mode dev` 模式来读取 `.env.dev`环境变量，并需要判断成 `development` 模式来走 resolve.alias 配置。所以我对您的代码做出以上修改，并且已在 `examples/demo` 下运行示例项目并测试通过。

如果您认为我的改动符合您的预期，烦请合并发布！