### PR TITLE
修复 rollup external globals 配置问题

### DIFF
--- a/packages/vite-plugin-external/package.json
+++ b/packages/vite-plugin-external/package.json
@@ -39,7 +39,8 @@
   "dependencies": {
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^14.18.63",
-    "fs-extra": "^11.1.1"
+    "fs-extra": "^11.1.1",
+    "rollup-plugin-external-globals": "^0.10.0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
- Rollup 新版里面的 globals 配置，[仅支持iife或者umd打包的库文件](https://github.com/rollup/rollup/issues/3188)，直接配置打包的话会出现错误。

- 下面这篇文章给出了解决办法：[https://blog.craftyun.cn/post/228.html](https://blog.craftyun.cn/post/228.html)

- 主要是实用rollup-plugin-external-globals插件进行配置。